### PR TITLE
Fix for encode error on file indexing

### DIFF
--- a/turbolift/operations/getfilenames.py
+++ b/turbolift/operations/getfilenames.py
@@ -41,8 +41,7 @@ class FileNames(object):
                                         os.sep)
                     for root, sfs, files in os.walk(rootdir.encode('utf8')):
                         for _fl in files:
-                            inode = os.path.join(root.encode('utf8'),
-                                                 _fl.encode('utf8'))
+                            inode = os.path.join(root, _fl)
                             if os.path.exists(inode):
                                 filelist.append(inode)
                         if self.tur_arg.get('debug'):


### PR DESCRIPTION
This is an intermittent issue that can happen
when indexing symbolic links and or NON-UTF8
characters. Encoding was removed in the index
method as the files will be properly encoded
upon upload.
