### PR TITLE
check if a file exists before adding it to the archive

### DIFF
--- a/turbolift/operations/compressfiles.py
+++ b/turbolift/operations/compressfiles.py
@@ -55,7 +55,8 @@ class Compressor(object):
 
             tar = tarfile.open(tmp_file, 'w:gz')
             for name in self.filelist:
-                tar.add(name)
+                if os.path.exists(name):
+                    tar.add(name)
             tar.close()
 
             # Set the Base Path for uploading the file


### PR DESCRIPTION
If you're adding a lot of files to an archive and a file is removed between the time that it is added to the filelist and the time that it is actually added to the archive, the script dies and complains that the file did not exist.

My particular use case is archiving a Jenkins /jobs/ directory (maintaining history in the backup) that included jobs that do their own cleanup such as removing history older than X days or X runs.

At nearly 100,000 files, it caused a slight bit of a race. Of course, Jenkins won every time.
