### PR TITLE
Added Better Support for Other Openstack Clouds

### DIFF
--- a/turbolift/utils/auth_utils.py
+++ b/turbolift/utils/auth_utils.py
@@ -98,7 +98,7 @@ def parse_auth_response(auth_response):
     elif ARGS.get('os_hp_auth') is not None:
         if ARGS.get('os_tenant') is None:
             raise turbo.NoTenantIdFound(
-                'You need to use have a tenant set to use HP Cloud'
+                'You need to have a tenant set to use HP Cloud'
             )
         region = ARGS.get('os_hp_auth')
     elif ARGS.get('os_region') is not None:


### PR DESCRIPTION
This commit now adds the ability for a user to leverage multiple openstack
clouds effortlessly.  I have added an "os-hp-auth" plugin to the command line
options which will allow an HP cloud consumer to use Turbolift to command
Swift "Object Store" as well as the CDN.

I have also improved the auth plugins to be more intutive as well as the
auth_utils.

Http utils is no longer tied to Rackspace public cloud when using
a url which has no prefix.
