### PR TITLE
Fix for Issue 31

### DIFF
--- a/turbolift/clouderator/actions.py
+++ b/turbolift/clouderator/actions.py
@@ -129,6 +129,8 @@ class CloudActions(object):
 
             # Perform Object GET
             conn.request('GET', rpath, headers=fheaders)
+            local_f = basic.collision_rename(file_name=local_f)
+
             # Open our source file and write it
             with open(local_f, 'ab') as f_name:
                 resp = http.response_get(conn=conn,

--- a/turbolift/methods/download.py
+++ b/turbolift/methods/download.py
@@ -84,7 +84,7 @@ class Download(object):
             concurrency = multi.set_concurrency(args=ARGS,
                                                 file_count=num_files)
             # Load the queue
-            obj_list = [obj['name'] for obj in objects]
+            obj_list = [obj['name'] for obj in objects if obj.get('name')]
 
         report.reporter(msg='Building Directory Structure.')
         with multi.spinner():

--- a/turbolift/utils/basic_utils.py
+++ b/turbolift/utils/basic_utils.py
@@ -178,6 +178,21 @@ def batch_gen(data, batch_size, count):
         yield data[dataset:dataset + batch_size]
 
 
+def collision_rename(file_name):
+    """Rename file on Collision.
+
+    If the file name is a directory and already exists rename the file to
+    %s.renamed, else return the file_name
+
+    :param file_name:
+    :return file_name:
+    """
+    if os.path.isdir(file_name):
+        return '%s.renamed' % file_name
+    else:
+        return file_name
+
+
 def mkdir_p(path):
     """'mkdir -p' in Python
 
@@ -209,7 +224,7 @@ def set_unique_dirs(object_list, root_dir):
 
     unique_dirs = []
     for obj in object_list:
-        full_path = jpath(root=root_dir, inode=obj)
+        full_path = jpath(root=root_dir, inode=obj.lstrip(os.sep))
         dir_path = full_path.split(
             os.path.basename(full_path)
         )[0].rstrip(os.sep)


### PR DESCRIPTION
BUG Updated download method

When downloading if unique directory is an empty string, the directory create
will fail. Additionally if an object was uploaded and has the same name as an
already created directory the specific file download will fail.

Related : https://github.com/cloudnull/turbolift/issues/31
