### PR TITLE
Add add_only option to cloning.

### DIFF
--- a/turbolift/arguments/clone.py
+++ b/turbolift/arguments/clone.py
@@ -55,3 +55,8 @@ def clone_actions(subparser, time_args):
                              ' is newer than the source. If "True" upload is'
                              ' skipped.'),
                        default=False)
+    clone.add_argument('--add-only',
+                       action='store_true',
+                       help=('Clone the object only if it doesn\'t exist in'
+                             ' the target container.'),
+                       default=False)

--- a/turbolift/clouderator/actions.py
+++ b/turbolift/clouderator/actions.py
@@ -743,6 +743,12 @@ class CloudActions(object):
                     prt=False
                 )
                 return True
+            elif ARGS.get('add_only'):
+                report.reporter(
+                    msg='Target Object %s already exists' % obj['name'],
+                    prt=True
+                )
+                return False
             elif obj_resp.getheader('etag') != obj['hash']:
                 report.reporter(
                     msg=('Checksum Mismatch on Target Object %s'


### PR DESCRIPTION
This adds an `add_only` option to cloning a container.

It will only clone objects which do not already exist (by name) on the target container.

If you think the naming structure should be different (or any other aspect), let me know. I also set `prt=True` in the reporter.
