### PR TITLE
Fix for issue 44

### DIFF
--- a/turbolift/utils/multi_utils.py
+++ b/turbolift/utils/multi_utils.py
@@ -104,7 +104,10 @@ def get_from_q(queue):
     except Queue.Empty:
         return None
     else:
-        return wfile.strip()
+        if isinstance(wfile, str):
+            return wfile.strip()
+        else:
+            return wfile
 
 
 def worker_proc(job_action, concurrency, queue, kwargs, opt):


### PR DESCRIPTION
When returning the working file, if the file is a string the we perform a
strip on the file, otherwise return the raw data.

https://github.com/cloudnull/turbolift/issues/44
