### PR TITLE
handle symlinks upload using X-Object-Manifest header

### DIFF
--- a/turbolift/methods/__init__.py
+++ b/turbolift/methods/__init__.py
@@ -33,12 +33,10 @@ def get_local_files():
         :param item:
         :return True|False:
         """
-        if all([not os.path.islink(item),
-                not os.path.ismount(item)]):
+        if not os.path.ismount(item):
             if not os.path.getsize(item) > 4831838208:
                 return True
-        else:
-            return False
+        return False
 
     def indexer(location):
         """Return a list of indexed files.


### PR DESCRIPTION
Added handling of symlinks (only those which links to something inside uploaded directory), using the X-Object-Manifest header.

I've tested it only against rackspace cloud files (with and without CDN), it works pretty well.
