### PR TITLE
Time offset compairison issues

### DIFF
--- a/turbolift/clouderator/actions.py
+++ b/turbolift/clouderator/actions.py
@@ -266,7 +266,7 @@ class CloudActions(object):
                 return_list = resp.json()
 
                 for obj in return_list:
-                    time_offset = ARGS.get('time_offset')
+                    time_offset = obj.get('last_modified')
                     if time_offset is not None:
                         # Get the last_modified data from the Object.
                         if cloud.time_delta(lmobj=time_offset) is True:


### PR DESCRIPTION
There was an issue with the last modified time stamp being pulled
from an object. The time offset variable was being used instead of
the last_modified value.

Closes: https://github.com/cloudnull/turbolift/issues/58
