### PR TITLE
This commit enforces unicode on a local index

### DIFF
--- a/turbolift/methods/__init__.py
+++ b/turbolift/methods/__init__.py
@@ -51,8 +51,10 @@ def get_local_files():
         if os.path.isdir(_location):
             r_walk = os.walk(_location)
             indexes = [(root, fls) for root, sfs, fls in r_walk]
-            return [basic.jpath(root=inx[0], inode=inode)
-                    for inx in indexes for inode in inx[1]]
+            return [
+                unicode(basic.jpath(root=inx[0], inode=inode))
+                for inx in indexes for inode in inx[1]
+            ]
         elif os.path.isfile(_location):
             return [_location]
         else:


### PR DESCRIPTION
By default python 2 uses byte encoding and will attempt to
compare byte encoded strings with unicode strings using 
internal conversion as part of the internal workings of python. 
With that said on some file systems it is likely that the program 
will encounter non-ascii compatible stings that can not be compared. 
This change ensures that all indexed files are encoded as unicode 
from the very beginning.

Issue Reference: https://github.com/cloudnull/turbolift/issues/59
