### PR TITLE
Fix setting logfile dir if running under cloudinit

### DIFF
--- a/turbolift/logger/logger.py
+++ b/turbolift/logger/logger.py
@@ -131,19 +131,20 @@ class LogSetup(object):
 
         If ``log_dir`` exists and the userID is 0 the log file will be written
         to the provided log directory. If the UserID is not 0 or log_dir does
-        not exist the log file will be written to the users home folder.
+        not exist the log file will be written to the users home folder. If the
+        users home folder cannot be obtained, /tmp will be used.
 
         :param filename: ``str``
         :param log_dir: ``str``
         :return: ``str``
         """
         user = os.getuid()
-        home = os.getenv('HOME')
+        home = os.getenv('HOME', '/tmp')
         default_log_location = os.path.join(home, filename)
         if not user == 0:
             return default_log_location
         else:
-            if os.path.isdir(log_dir):
+            if log_dir and os.path.isdir(log_dir):
                 return os.path.join(log_dir, filename)
             else:
                 return default_log_location


### PR DESCRIPTION
When running under cloud-init (or any other scenario where environment variables are not configured), turbolift crashes with the following traceback

```
Traceback (most recent call last):
  File "/usr/bin/turbolift", line 9, in <module>
    load_entry_point('turbolift==2.1.3', 'console_scripts', 'turbolift')()
  File "/usr/lib/python2.6/site-packages/turbolift/executable.py", line 32, in run_turbolift
    ).default_logger(enable_stream=args.get('log_streaming'))
  File "/usr/lib/python2.6/site-packages/turbolift/logger/logger.py", line 94, in default_logger
    filename=log_file_name, log_dir=self.log_dir
  File "/usr/lib/python2.6/site-packages/turbolift/logger/logger.py", line 142, in return_logfile
    default_log_location = os.path.join(home, filename)
  File "/usr/lib64/python2.6/posixpath.py", line 67, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```

Turbolift will also crash with if running as root and ```--log-location``` is not defined in the commandline

```
Traceback (most recent call last):
  File "/usr/bin/turbolift", line 9, in <module>
    load_entry_point('turbolift==2.1.3', 'console_scripts', 'turbolift')()
  File "/usr/lib/python2.6/site-packages/turbolift/executable.py", line 32, in run_turbolift
    ).default_logger(enable_stream=args.get('log_streaming'))
  File "/usr/lib/python2.6/site-packages/turbolift/logger/logger.py", line 94, in default_logger
    filename=log_file_name, log_dir=self.log_dir
  File "/usr/lib/python2.6/site-packages/turbolift/logger/logger.py", line 146, in return_logfile
    if os.path.isdir(log_dir):
  File "/usr/lib64/python2.6/genericpath.py", line 41, in isdir
    st = os.stat(s)
TypeError: coercing to Unicode: need string or buffer, NoneType found
```

A current workaround would be to define the HOME env variable in the cloud-init script and define ```--log-location```

```HOME=/root/ turbolift --log-location /var/log/ -u username -a apikey --os-rax-auth lon download -c container -s /tmp/test```

to reproduce the issue:

```env -i turbolift -u username -a apikey --os-rax-auth lon download -c container -s /tmp/test```