### PR TITLE
Fix typo

### DIFF
--- a/turbolift/authentication/utils.py
+++ b/turbolift/authentication/utils.py
@@ -10,7 +10,7 @@
 
 import traceback
 try:
-    import urlparsre
+    import urlparse
 except ImportError:
     import urllib.parse as urlparse
 

--- a/turbolift/clouderator/actions.py
+++ b/turbolift/clouderator/actions.py
@@ -14,7 +14,7 @@ import io
 import os
 import pwd
 try:
-    import urlparsre
+    import urlparse
 except ImportError:
     import urllib.parse as urlparse
 


### PR DESCRIPTION
Right now python 2.x will fail with the following stack trace:

```
$ turbolift --version
Traceback (most recent call last):
  File "/usr/local/bin/turbolift", line 9, in <module>
    load_entry_point('turbolift==3.0.0', 'console_scripts', 'turbolift')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 521, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2632, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2312, in load
    return self.resolve()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2318, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "build/bdist.linux-x86_64/egg/turbolift/executable.py", line 18, in <module>
  File "build/bdist.linux-x86_64/egg/turbolift/worker.py", line 14, in <module>
  File "build/bdist.linux-x86_64/egg/turbolift/authentication/auth.py", line 6, in <module>
  File "build/bdist.linux-x86_64/egg/turbolift/authentication/utils.py", line 15, in <module>
ImportError: No module named parse
```

Since it can't find `urlparsre` it tries to load python 3 modules, flails and panics