### PR TITLE
Updates archive method so it can handle large files.

### DIFF
--- a/turbolift/__init__.py
+++ b/turbolift/__init__.py
@@ -171,6 +171,28 @@ ARGUMENTS = {
             'default': 2048,
             'type': int,
             'metavar': '[INT]'
+        },
+        'chunk_size': {
+            'commands': [
+                '--chunk-size'
+            ],
+            'help': 'Set the default byte size a object that is larger'
+                    ' then "[--large-object-size]" will be chunked'
+                    ' this size. Default: %(default)s',
+            'default': 524288000,
+            'type': int,
+            'metavar': '[INT]'
+        },
+        'large_object_size': {
+            'commands': [
+                '--large-object-size'
+            ],
+            'help': 'Set the default byte size of the large object'
+                    ' threshold that is larger then 5GB will be'
+                    ' chunked at. Default: %(default)s',
+            'default': 5153960756,
+            'type': int,
+            'metavar': '[INT]'
         }
     },
     'optional_args': {
@@ -425,7 +447,9 @@ ARGUMENTS = {
             'shared_args': [
                 'object',
                 'directory',
-                'container'
+                'container',
+                'chunk_size',
+                'large_object_size'
             ],
             'optional_args': {
                 'tar_name': {
@@ -906,7 +930,9 @@ ARGUMENTS = {
                 'object',
                 'sync',
                 'max_jobs',
-                'object_headers'
+                'object_headers',
+                'chunk_size',
+                'large_object_size'
             ],
             'optional_args': {
                 'groups': {
@@ -926,28 +952,6 @@ ARGUMENTS = {
                             'large_object_size'
                         ]
                     }
-                },
-                'chunk_size': {
-                    'commands': [
-                        '--chunk-size'
-                    ],
-                    'help': 'Set the default byte size a object that is larger'
-                            ' then "[--large-object-size]" will be chunked'
-                            ' this size. Default: %(default)s',
-                    'default': 524288000,
-                    'type': int,
-                    'metavar': '[INT]'
-                },
-                'large_object_size': {
-                    'commands': [
-                        '--large-object-size'
-                    ],
-                    'help': 'Set the default byte size of the large object'
-                            ' threshold that is larger then 5GB will be'
-                            ' chunked at. Default: %(default)s',
-                    'default': 5153960756,
-                    'type': int,
-                    'metavar': '[INT]'
                 },
                 'exclude': {
                     'commands': [

--- a/turbolift/methods/archive.py
+++ b/turbolift/methods/archive.py
@@ -35,8 +35,14 @@ class ArchiveRunMethod(methods.BaseMethod):
             self._put_container()
 
         LOG.info('Uploading Archive...')
-        with indicator.Spinner(**self.indicator_options):
-            self._upload(**archive)
+        upload_objects = self._return_deque()
+        archive_item = self._encapsulate_object(
+            full_path=archive['local_object'],
+            split_path=os.path.dirname(archive['local_object'])
+        )
+        upload_objects.append(archive_item)
+
+        self._multi_processor(self._upload, items=upload_objects)
 
         if not self.job_args.get('no_cleanup'):
             os.remove(archive['local_object'])


### PR DESCRIPTION
We've been using the archive method to upload backups to Rackspace. Recently we surpassed the 5GB limit on single objects.

This pull request updates the archive method to support chunked upload.

- I added shared_args for `chunk_size` and `large_object_size`.
- I had to do some digging to figure out how to get the archive object ready for the multi processor.
- I didn't want to change the return value of the compressor method. It might make sense to move some of this inside the compressor method. Thoughts?

I didn't see any tests, so if you have a way to test this more thoroughly, let me know.

And of course, if you see anything I should change, feedback welcome. Thanks.